### PR TITLE
Show submissions from all clients

### DIFF
--- a/src/cmd/cmdimp.cpp
+++ b/src/cmd/cmdimp.cpp
@@ -661,7 +661,6 @@ int show_scores(cmdargs &cmd) {
   LogDebug("Found " << subs.size() << " submissions." << Logger::endl);
 
   Logger::info << "Scores for " << course_name << ":" << asmt_name << Logger::endl
-    << "(Only submissions made via this client can be shown)" << Logger::endl
     << Logger::endl;
 
   std::vector<std::vector<std::string>> sub_table;


### PR DESCRIPTION
autolab/Autolab#1006 removed the restraint that a client can only see its own submissions. The output text that explains this restraint is now removed from the cli.