### PR TITLE
Show Number of Unpenalized Submissions in Autolab CLI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "Build variant: ${variant}")
 
 # compiler flags
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Werror")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 

--- a/include/autolab/autolab.h
+++ b/include/autolab/autolab.h
@@ -68,6 +68,7 @@ struct DetailedAssessment {
   std::string description;
   int max_grace_days;
   int max_submissions;
+  int max_unpenalized_submissions;
   int group_size;
   bool disable_handins;
   bool has_scoreboard;

--- a/lib/autolab/client.cpp
+++ b/lib/autolab/client.cpp
@@ -147,6 +147,7 @@ void Client::get_assessment_details(DetailedAssessment &dasmt,
   dasmt.description     = get_string(dasmt_doc, "description");
   dasmt.max_grace_days  = get_int(dasmt_doc, "max_grace_days", -1);
   dasmt.max_submissions = get_int(dasmt_doc, "max_submissions", -1);
+  dasmt.max_unpenalized_submissions = get_int(dasmt_doc, "max_unpenalized_submissions", -1);
   dasmt.group_size      = get_int(dasmt_doc, "group_size", 1);
   dasmt.disable_handins = get_bool(dasmt_doc, "disable_handins", false);
   dasmt.has_scoreboard  = get_bool(dasmt_doc, "has_scoreboard", false);

--- a/src/cmd/cmdimp.cpp
+++ b/src/cmd/cmdimp.cpp
@@ -189,6 +189,14 @@ int show_status(cmdargs &cmd) {
     Logger::info << dasmt.max_submissions << Logger::endl;
   }
 
+  Logger::info << "Max penalty-free submissions: ";
+
+  if (dasmt.max_unpenalized_submissions < 0) {
+    Logger::info << "Infinite" << Logger::endl;
+  } else {
+    Logger::info << dasmt.max_unpenalized_submissions << Logger::endl;
+  }
+
   Logger::info << "Max grace days: ";
   if (dasmt.max_grace_days < 0) {
     Logger::info << "As many as you have left" << Logger::endl;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Show `max_unpenalized_submissions` field to be added to API. Should only be used in conjunction with autolab/Autolab#1333

Temporarily "fixed" a build error by removing the `-Werror` flag

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We want to show clients (especially in the CLI) the number of submissions they can make before they start incurring version penalties. See autolab/Autolab#1184

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built locally, but quite frankly, I didn't test it very thoroughly. Should do the whole nine yards and link local executable copy of CLI to local copy of Autolab and test with API

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Other issues / help required
<!--- Do you have any other relevant issues / questions? --->
<!--- For example, if you require assistance for a certain part of your PR --->
<!--- or are facing specific issues while creating the pull request that you would like to highlight --->

If unsure, feel free to submit first and we'll help you along.
