### PR TITLE
Better handling for cache key errors

### DIFF
--- a/include/autolab/autolab.h
+++ b/include/autolab/autolab.h
@@ -128,8 +128,8 @@ class HttpException: public std::exception {
 private:
   std::string msg;
 public:
-  explicit HttpException(std::string m) : msg(m) {}
-  virtual const char* what() const throw() {
+  explicit HttpException(std::string m) : msg(std::move(m)) {}
+  const char* what() const noexcept override {
       return msg.c_str();
   }
 };
@@ -138,7 +138,7 @@ public:
 // A new set of tokens should be acquired by re-preforming user authorization.
 class InvalidTokenException: public std::exception {
 public:
-  virtual const char* what() const throw() {
+  const char* what() const noexcept override {
       return "The provided access token is invalid and the refresh operation failed.";
   }
 };
@@ -149,8 +149,8 @@ class InvalidResponseException: public std::exception {
 private:
   std::string msg;
 public:
-  explicit InvalidResponseException(std::string m) : msg(m) {}
-  virtual const char* what() const throw() {
+  explicit InvalidResponseException(std::string m) : msg(std::move(m)) {}
+  const char* what() const noexcept override {
       return msg.c_str();
   }
 };
@@ -163,10 +163,22 @@ class ErrorResponseException: public std::exception {
 private:
   std::string msg;
 public:
-  explicit ErrorResponseException(std::string m) : msg(m) {}
-  virtual const char* what() const throw() {
+  explicit ErrorResponseException(std::string m) : msg(std::move(m)) {}
+  const char* what() const noexcept override {
       return msg.c_str();
   }
+};
+
+// Indicates that an error occurred while encrypting or decrypting data.
+// This exception's msg will contain the error message returned by openssl.
+class CryptoException: public std::exception {
+private:
+  std::string msg;
+public:
+    explicit CryptoException(std::string m) : msg(std::move(m)) {}
+    const char* what() const noexcept override {
+        return msg.c_str();
+    }
 };
 
 namespace Utility {

--- a/include/autolab/autolab.h
+++ b/include/autolab/autolab.h
@@ -59,8 +59,6 @@ struct Assessment {
   std::time_t start_at;
   std::time_t due_at;
   std::time_t end_at;
-  // available only if user is an instructor of the course
-  std::time_t grading_deadline;
 };
 
 struct DetailedAssessment {

--- a/lib/autolab/client.cpp
+++ b/lib/autolab/client.cpp
@@ -75,7 +75,6 @@ void assessment_from_json(Assessment &asmt, rapidjson::Value &asmt_json) {
   asmt.start_at = Utility::string_to_time(get_string_force(asmt_json, "start_at"));
   asmt.due_at   = Utility::string_to_time(get_string_force(asmt_json, "due_at"));
   asmt.end_at   = Utility::string_to_time(get_string_force(asmt_json, "end_at"));
-  asmt.grading_deadline = Utility::string_to_time(get_string(asmt_json, "grading_deadline"));
 }
 
 void enrollment_from_json(Enrollment &enrollment, rapidjson::Value &enrollment_json) {

--- a/src/context_manager/context_manager.cpp
+++ b/src/context_manager/context_manager.cpp
@@ -77,7 +77,8 @@ void store_tokens(std::string at, std::string rt) {
       write_file(get_token_cache_file_full_path().c_str(),
                  token_pair.c_str(), token_pair.length());
   } catch (Autolab::CryptoException &e) {
-    Logger::fatal << "OpenSSL error in store_tokens " << e.what() << Logger::endl;
+    Logger::fatal << "OpenSSL error in store_tokens." << Logger::endl;
+    Logger::fatal << e.what() << Logger::endl;
     exit(-1);
   }
   LogDebug("[ContextManager] tokens stored" << Logger::endl);
@@ -97,7 +98,9 @@ bool load_tokens(std::string &at, std::string &rt) {
   try {
     if (!token_pair_from_string(raw_result, num_read, at, rt)) return false;
   } catch (Autolab::CryptoException &e) {
-    Logger::fatal << "OpenSSL error in load_tokens " << e.what() << Logger::endl;
+    Logger::fatal << "OpenSSL error in load_tokens." << Logger::endl;
+    Logger::fatal << e.what() << Logger::endl;
+    remove(get_token_cache_file_full_path().c_str());
     return false;
   }
   LogDebug("[ContextManager] tokens loaded" << Logger::endl);

--- a/src/context_manager/context_manager.cpp
+++ b/src/context_manager/context_manager.cpp
@@ -98,8 +98,9 @@ bool load_tokens(std::string &at, std::string &rt) {
   try {
     if (!token_pair_from_string(raw_result, num_read, at, rt)) return false;
   } catch (Autolab::CryptoException &e) {
-    Logger::fatal << "OpenSSL error in load_tokens." << Logger::endl;
-    Logger::fatal << e.what() << Logger::endl;
+    LogDebug("OpenSSL error in load_tokens." << Logger::endl);
+    LogDebug(e.what() << Logger::endl);
+    LogDebug("Removing token cache file." << Logger::endl);
     remove(get_token_cache_file_full_path().c_str());
     return false;
   }

--- a/src/context_manager/context_manager.cpp
+++ b/src/context_manager/context_manager.cpp
@@ -2,6 +2,7 @@
 
 #include "../app_credentials.h"
 #include "../file/file_utils.h"
+#include "autolab/autolab.h"
 #include "logger.h"
 #include "../crypto/pseudocrypto.h"
 
@@ -70,10 +71,15 @@ bool token_cache_file_exists() {
 /* interface */
 void store_tokens(std::string at, std::string rt) {
   check_and_create_token_directory();
-  std::string token_pair = token_pair_to_string(at, rt);
+  try {
+      std::string token_pair = token_pair_to_string(at, rt);
 
-  write_file(get_token_cache_file_full_path().c_str(),
-             token_pair.c_str(), token_pair.length());
+      write_file(get_token_cache_file_full_path().c_str(),
+                 token_pair.c_str(), token_pair.length());
+  } catch (Autolab::CryptoException &e) {
+    Logger::fatal << "OpenSSL error in store_tokens " << e.what() << Logger::endl;
+    exit(-1);
+  }
   LogDebug("[ContextManager] tokens stored" << Logger::endl);
 }
 
@@ -88,7 +94,12 @@ bool load_tokens(std::string &at, std::string &rt) {
             raw_result, TOKEN_CACHE_FILE_MAXSIZE);
   LogDebug("read size " << num_read << "\n");
 
-  if (!token_pair_from_string(raw_result, num_read, at, rt)) return false;
+  try {
+    if (!token_pair_from_string(raw_result, num_read, at, rt)) return false;
+  } catch (Autolab::CryptoException &e) {
+    Logger::fatal << "OpenSSL error in load_tokens " << e.what() << Logger::endl;
+    return false;
+  }
   LogDebug("[ContextManager] tokens loaded" << Logger::endl);
   return true;
 }

--- a/src/crypto/pseudocrypto.cpp
+++ b/src/crypto/pseudocrypto.cpp
@@ -7,14 +7,13 @@
 #include <openssl/err.h>
 #include <openssl/evp.h>
 
+#include "autolab/autolab.h"
 #include "logger.h"
 
 #define MAX_CIPHERTEXT_LEN 256
 
-void exit_with_crypto_error() {
-  Logger::fatal << "OpenSSL error" << Logger::endl;
-  ERR_print_errors_fp(stderr);
-  exit(-1);
+void raise_crypto_error() {
+  throw Autolab::CryptoException(ERR_error_string(ERR_get_error(), nullptr));
 }
 
 void check_key_and_iv_lengths(unsigned char *key, unsigned char *iv) {
@@ -42,17 +41,17 @@ std::string encrypt_string(std::string srctext, unsigned char *key,
 
   // create context
   if (!(ctx = EVP_CIPHER_CTX_new()))
-    exit_with_crypto_error();
+    raise_crypto_error();
 
-  if (1 != EVP_EncryptInit_ex(ctx, EVP_aes_256_cbc(), NULL, key, iv))
-    exit_with_crypto_error();
+  if (1 != EVP_EncryptInit_ex(ctx, EVP_aes_256_cbc(), nullptr, key, iv))
+    raise_crypto_error();
 
   if (1 != EVP_EncryptUpdate(ctx, ciphertext, &temp_len, plaintext, input_len))
-    exit_with_crypto_error();
+    raise_crypto_error();
   total_len = temp_len;
 
   if (1 != EVP_EncryptFinal_ex(ctx, ciphertext + temp_len, &temp_len))
-    exit_with_crypto_error();
+    raise_crypto_error();
   total_len += temp_len;
 
   EVP_CIPHER_CTX_free(ctx);
@@ -74,17 +73,17 @@ std::string decrypt_string(char *srctext, size_t srclength, unsigned char *key,
   int input_len = (int)srclength;
 
   if (!(ctx = EVP_CIPHER_CTX_new()))
-    exit_with_crypto_error();
+    raise_crypto_error();
 
-  if (1 != EVP_DecryptInit_ex(ctx, EVP_aes_256_cbc(), NULL, key, iv))
-    exit_with_crypto_error();
+  if (1 != EVP_DecryptInit_ex(ctx, EVP_aes_256_cbc(), nullptr, key, iv))
+    raise_crypto_error();
 
   if (1 != EVP_DecryptUpdate(ctx, plaintext, &temp_len, ciphertext, input_len))
-    exit_with_crypto_error();
+    raise_crypto_error();
   total_len = temp_len;
 
   if (1 != EVP_DecryptFinal_ex(ctx, plaintext + temp_len, &temp_len))
-    exit_with_crypto_error();
+    raise_crypto_error();
   total_len += temp_len;
 
   EVP_CIPHER_CTX_free(ctx);


### PR DESCRIPTION
When loading tokens from the `.arcache` fails, proactively delete the file, so that the user is forced to set-up the CLI again.

Also, remove `grading_deadline` logic.

Closes #23

To test:
- Set up autolab CLI (in debug mode)
- Try loading an assessment, make sure there no `string_to_time parse fail!` messages (previously caused by attempting to parse `grading_deadline`)
- Ensure that `.autolab/.arcache` file exists in user home directory
- Update `crypto_key` in `app_credentials.h`, and rebuild CLI
- Try loading an assessment again, get error message

<img width="488" alt="Screenshot 2024-05-15 at 22 17 45" src="https://github.com/autolab/Autolab-CLI/assets/9074856/76ef7e7f-149a-479c-b04e-47e197b2ee98">

- Check that `.autolab/.arcache` file has been removed
- Try loading an assessment again - no more error about `load_tokens`

<img width="467" alt="Screenshot 2024-05-15 at 22 18 04" src="https://github.com/autolab/Autolab-CLI/assets/9074856/ce502aea-3fab-4a69-b562-6c2a986454d1">