### PR TITLE
Add debug builds to CI

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -20,7 +20,7 @@ jobs:
 
       matrix:
         os: [ubuntu-latest, macos-latest]
-        build_type: [Release]
+        build_type: [Release, Debug]
 
     steps:
       - uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,15 +11,20 @@ set(variant "" CACHE STRING "build variant")
 # command line options
 option(release "build release version (no debug output)" OFF)
 
-if(NOT release)
-  # build debug
-  set(CMAKE_BUILD_TYPE Debug)
+# Existing CMAKE_BUILD_TYPE takes priority if directly defined
+if(NOT CMAKE_BUILD_TYPE)
+  if(release)
+    set(CMAKE_BUILD_TYPE Release)
+  else()
+    set(CMAKE_BUILD_TYPE Debug)
+  endif()
+endif()
+
+if(CMAKE_BUILD_TYPE MATCHES Debug)
   set(PRINT_DEBUG TRUE)
-else(NOT release)
-  # build release
-  set(CMAKE_BUILD_TYPE Release)
+else()
   set(PRINT_DEBUG FALSE)
-endif(NOT release)
+endif()
 
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "Build variant: ${variant}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 project(autolab-cli)
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ This will move our autocompletion script out of a local folder and into the bash
 
 #### Release vs Debug
 
-There are two kinds of builds available: release and non-release. Release builds do not contain debug output (output that use `Logger::debug`).
+There are two kinds of builds available: release and debug. Release builds do not contain debug output (output that use `Logger::debug`).
 
-The default is non-release builds. To build a release version, when inside the 'build' directory, run `cmake -DCMAKE_BUILD_TYPE=Release ..` (note the periods at the end), then run `make`.
+The default are debug builds. To build a release version, when inside the 'build' directory, run `cmake -DCMAKE_BUILD_TYPE=Release ..` (note the periods at the end), then run `make`.
 Alternatively (but less preferable), you can use the flag `-Drelease=ON`.
 
 #### Build Variant

--- a/README.md
+++ b/README.md
@@ -70,9 +70,10 @@ This will move our autocompletion script out of a local folder and into the bash
 
 #### Release vs Debug
 
-There are two kinds of builds available: release and non-release. Release builds do not contain debug output (output that use Logger::debug).
+There are two kinds of builds available: release and non-release. Release builds do not contain debug output (output that use `Logger::debug`).
 
-The default is non-release builds. To build a release version, when inside the 'build' directory, run `cmake -Drelease=ON ..` (note the periods at the end), then run `make`.
+The default is non-release builds. To build a release version, when inside the 'build' directory, run `cmake -DCMAKE_BUILD_TYPE=Release ..` (note the periods at the end), then run `make`.
+Alternatively (but less preferable), you can use the flag `-Drelease=ON`.
 
 #### Build Variant
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This will move our autocompletion script out of a local folder and into the bash
 
 There are two kinds of builds available: release and debug. Release builds do not contain debug output (output that use `Logger::debug`).
 
-The default are debug builds. To build a release version, when inside the 'build' directory, run `cmake -DCMAKE_BUILD_TYPE=Release ..` (note the periods at the end), then run `make`.
+The default is debug builds. To build a release version, when inside the 'build' directory, run `cmake -DCMAKE_BUILD_TYPE=Release ..` (note the periods at the end), then run `make`.
 Alternatively (but less preferable), you can use the flag `-Drelease=ON`.
 
 #### Build Variant

--- a/lib/logger/logger.h
+++ b/lib/logger/logger.h
@@ -73,7 +73,7 @@ namespace Logger {
   };
   struct debug_logger {
     template<class T>
-    debug_logger &operator<<(T val) {
+    debug_logger &operator<<([[maybe_unused]] T val) {
     #ifdef PRINT_DEBUG
       std::cout << val;
     #endif


### PR DESCRIPTION
This PR fixes the CI to correctly build release builds by changing the way that `CMAKE_BUILD_TYPE` is handled.

It also adds debug builds to the CI.

**To check**: view the CI checks and ensure that the correct build type is displayed under the "Configure CMake" task. You can also experiment with combinations of `-DCMAKE_BUILD_TYPE` and `-DRelease`, but note that `CMAKE_BUILD_TYPE` is cached.